### PR TITLE
Change old package name on utils.go

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -19,7 +19,7 @@ func buildMockOnePassword() (string, error) {
 	cmd := exec.Command(
 		"go",
 		"install",
-		"github.com/ameier38/onepassword/cmd/mock-op")
+		"github.com/ContainerSolutions/onepassword/cmd/mock-op")
 
 	if output, err := cmd.CombinedOutput(); err != nil {
 		return "", fmt.Errorf("failed to build mock op program: %s\n%s", err, output)


### PR DESCRIPTION
Hi there 👋 

This PR changes the old fork name in a string on `utils.go`. It was messing with the `go.mod` and `go.sum` during tests by importing the `ameier38/onepassword` package.